### PR TITLE
Fixed an error when deleting an array.

### DIFF
--- a/source/point_cloud_registration.hpp
+++ b/source/point_cloud_registration.hpp
@@ -454,7 +454,7 @@ class Point_cloud_registration
                     }
                 }
                 residual_block_ids = residual_block_ids_temp;
-                delete probability_to_drop;
+                delete[] probability_to_drop;
             }
 
             ceres::Solver::Options options;


### PR DESCRIPTION

I think I found the error from issue #45 . 
An array is created and then deleted as if is was a regular pointer. 